### PR TITLE
Pull changes if repo directory already exists

### DIFF
--- a/calimero.sh
+++ b/calimero.sh
@@ -51,6 +51,8 @@ export CALIMERO_SERVER_USER=knx
 export CALIMERO_SERVER_GROUP=knx
 # KNX Server Name
 export KNX_SERVER_NAME="Calimero KNXnet/IP Server"
+###############################################################################
+# Usage
 if [ "$1" = "-?" ] || [ "$1" = "-h" ] || [ "$1" = "--help" ];then
 	echo Usage $0 "[usb|tunnel ip-tunnel-endpoint]"
 	exit 0
@@ -80,8 +82,6 @@ elif [ "$1" = "tunnel" ] || [ "$1" = "--tunnel" ];then
         echo Example: $0 tunnel 192.166.200.200
 		exit 4
     fi
-elif [ "$1" = "-?" ] || [ "$1" = "-h" ] || [ "$1" = "--help" ];then 	
-	echo Usage $0 [usb|tunnel ip-tunnel-endpoint]
 else
     echo Configure support for TPUART
     export KNX_CONNECTION=TPUART

--- a/calimero.sh
+++ b/calimero.sh
@@ -651,7 +651,7 @@ After=network.target
 #ExecStartPre=/lib/systemd/systemd-networkd-wait-online --timeout=60
 # Wait for a specific interface
 #ExecStartPre=/lib/systemd/systemd-networkd-wait-online --timeout=60 --interface=eth0
-ExecStart=/usr/bin/java -cp "$CALIMERO_SERVER_PATH/*" tuwien.auto.calimero.server.Launcher $CALIMERO_CONFIG_PATH/server-config.xml
+ExecStart=/usr/bin/java -cp "$CALIMERO_CONFIG_PATH:$CALIMERO_SERVER_PATH/*" tuwien.auto.calimero.server.Launcher $CALIMERO_CONFIG_PATH/server-config.xml
 Type=simple
 User=$CALIMERO_SERVER_USER
 Group=$CALIMERO_SERVER_GROUP

--- a/calimero.sh
+++ b/calimero.sh
@@ -307,26 +307,50 @@ ACTION=="add", SUBSYSTEM=="tty", ATTRS{idVendor}=="03eb", ATTRS{idProduct}=="204
 # ACTION=="add",SUBSYSTEM=="tty", ATTR{port}=="0x3F8",SYMLINK+="ttyTPUART1",RUN+="/bin/setserial /dev/%k low_latency", GROUP="dialout", MODE="0664"
 EOF
 
+# clones the repo if the directory doesn't exist, otherwise pulls while preserving local changes
+# $1 name of repository
+clone_update_repo() {
+	if [ -d $1 ]; then
+		cd $1
+
+		# make sure we have a user for git
+		git config user.name "$(whoami)"
+		git config user.email "$(whoami)@rpi"
+
+		echo "update $1, preserve local changes"
+
+		ts=$(date +%s) # timestamp the stash
+		msg=$(git stash save $ts " local changes before updating from upstream")
+		git pull
+
+		# check if we stashed anything
+		ret=$(grep -q "$ts" <<< "$msg") || true
+		ret=$?
+		if [ "$ret" -eq 0 ] ; then
+			git stash pop || true
+		fi
+	else
+		git clone https://github.com/calimero-project/$1 $1
+		cd $1
+	fi
+}
 
 ############################# Build ###########################################
 # calimero-core
 cd $CALIMERO_BUILD
-git clone https://github.com/calimero-project/calimero-core calimero-core || (cd calimero-core ; git pull)
-cd calimero-core
+clone_update_repo calimero-core
 ./gradlew assemble
 cp ./build/libs/calimero-core-2.4-SNAPSHOT.jar $CALIMERO_SERVER_PATH
 
 # calimero device
-cd $CALIMERO_BUILD 
-git clone https://github.com/calimero-project/calimero-device calimero-device || (cd calimero-device ; git pull)
-cd calimero-device
+cd $CALIMERO_BUILD
+clone_update_repo calimero-device
 ./gradlew assemble
 cp ./build/libs/calimero-device-2.4-SNAPSHOT.jar $CALIMERO_SERVER_PATH
 
 # serial-native
 cd $CALIMERO_BUILD
-git clone https://github.com/calimero-project/serial-native serial-native || (cd serial-native ; git pull)
-cd $CALIMERO_BUILD/serial-native
+clone_update_repo serial-native
 # Set Java home
 xmlstarlet ed --inplace -N x=http://maven.apache.org/POM/4.0.0 -u 'x:project/x:properties/x:java.home' -v "$JAVA_HOME_PATH" pom.xml
 # Compile
@@ -341,15 +365,13 @@ fi
 
 # calimero-rxtx
 cd $CALIMERO_BUILD
-git clone https://github.com/calimero-project/calimero-rxtx.git calimero-rxtx || (cd calimero-rxtx ; git pull)
-cd calimero-rxtx
+clone_update_repo calimero-rxtx
 ./gradlew build
 cp ./build/libs/calimero-rxtx-2.4-SNAPSHOT.jar $CALIMERO_SERVER_PATH
 
 # calimero-server
 cd $CALIMERO_BUILD
-git clone https://github.com/calimero-project/calimero-server calimero-server || (cd calimero-server ; git pull)
-cd $CALIMERO_BUILD/calimero-server
+clone_update_repo calimero-server
 #
 # Patch for prevent stopping calimero-server when STDIN ReadLine() return null, patch saved as base64 to create the patch file properly: cat STDINPatch.patch|base64
 #   --- src/tuwien/auto/calimero/server/Launcher.java.org	2018-04-09 18:48:21.530275110 +0200
@@ -418,8 +440,7 @@ cp ./build/libs/calimero-server-2.4-SNAPSHOT.jar $CALIMERO_SERVER_PATH
 
 ########################## Calimero Client Tools ##############################
 cd $CALIMERO_BUILD
-git clone https://github.com/calimero-project/calimero-tools calimero-tools || (cd calimero-tools ; git pull)
-cd calimero-tools
+clone_update_repo calimero-tools
 ./gradlew assemble
 cp ./build/libs/calimero-tools-2.4-SNAPSHOT.jar $CALIMERO_SERVER_PATH
 # Tools wrapper

--- a/calimero.sh
+++ b/calimero.sh
@@ -157,8 +157,10 @@ mkdir -p $CALIMERO_SERVER_PATH
 mkdir -p $CALIMERO_CONFIG_PATH
 
 ########################## Requiered packages #################################
+if [ -z "$(find /var/cache/apt/pkgcache.bin -mmin -120)" ]; then
 apt-get -y update 
 apt-get -y upgrade
+fi
 apt-get -y install setserial
 apt-get -y install git maven
 apt-get -y install build-essential cmake

--- a/calimero.sh
+++ b/calimero.sh
@@ -54,7 +54,7 @@ export KNX_SERVER_NAME="Calimero KNXnet/IP Server"
 ###############################################################################
 # Usage
 if [ "$1" = "-?" ] || [ "$1" = "-h" ] || [ "$1" = "--help" ];then
-	echo Usage $0 "[usb|tunnel ip-tunnel-endpoint]"
+	echo Usage $0 "[tpuart|usb|tunnel ip-tunnel-endpoint|clean]"
 	exit 0
 fi
 ###############################################################################
@@ -82,6 +82,15 @@ elif [ "$1" = "tunnel" ] || [ "$1" = "--tunnel" ];then
         echo Example: $0 tunnel 192.166.200.200
 		exit 4
     fi
+elif [ "$1" = "clean" ]; then
+	# Check on zero for $CALIMERO_BUILD to avoid "cleaning" the wrong directory
+	if [ ! -z $CALIMERO_BUILD ] && [ -d $CALIMERO_BUILD ]; then
+		rm -r $CALIMERO_BUILD
+	fi
+	exit 0  
+elif [ "$1" = "tpuart" ] || [ "$1" = "--tpuart" ];then
+    echo Configure support for TPUART
+    export KNX_CONNECTION=TPUART    
 else
     echo Configure support for TPUART
     export KNX_CONNECTION=TPUART

--- a/calimero.sh
+++ b/calimero.sh
@@ -311,21 +311,21 @@ EOF
 ############################# Build ###########################################
 # calimero-core
 cd $CALIMERO_BUILD
-git clone https://github.com/calimero-project/calimero-core calimero-core
+git clone https://github.com/calimero-project/calimero-core calimero-core || (cd calimero-core ; git pull)
 cd calimero-core
 ./gradlew assemble
 cp ./build/libs/calimero-core-2.4-SNAPSHOT.jar $CALIMERO_SERVER_PATH
 
 # calimero device
 cd $CALIMERO_BUILD 
-git clone https://github.com/calimero-project/calimero-device calimero-device
+git clone https://github.com/calimero-project/calimero-device calimero-device || (cd calimero-device ; git pull)
 cd calimero-device
 ./gradlew assemble
 cp ./build/libs/calimero-device-2.4-SNAPSHOT.jar $CALIMERO_SERVER_PATH
 
 # serial-native
 cd $CALIMERO_BUILD
-git clone https://github.com/calimero-project/serial-native serial-native
+git clone https://github.com/calimero-project/serial-native serial-native || (cd serial-native ; git pull)
 cd $CALIMERO_BUILD/serial-native
 # Set Java home
 xmlstarlet ed --inplace -N x=http://maven.apache.org/POM/4.0.0 -u 'x:project/x:properties/x:java.home' -v "$JAVA_HOME_PATH" pom.xml
@@ -341,14 +341,14 @@ fi
 
 # calimero-rxtx
 cd $CALIMERO_BUILD
-git clone https://github.com/calimero-project/calimero-rxtx.git calimero-rxtx
+git clone https://github.com/calimero-project/calimero-rxtx.git calimero-rxtx || (cd calimero-rxtx ; git pull)
 cd calimero-rxtx
 ./gradlew build
 cp ./build/libs/calimero-rxtx-2.4-SNAPSHOT.jar $CALIMERO_SERVER_PATH
 
 # calimero-server
 cd $CALIMERO_BUILD
-git clone https://github.com/calimero-project/calimero-server calimero-server
+git clone https://github.com/calimero-project/calimero-server calimero-server || (cd calimero-server ; git pull)
 cd $CALIMERO_BUILD/calimero-server
 #
 # Patch for prevent stopping calimero-server when STDIN ReadLine() return null, patch saved as base64 to create the patch file properly: cat STDINPatch.patch|base64
@@ -418,7 +418,7 @@ cp ./build/libs/calimero-server-2.4-SNAPSHOT.jar $CALIMERO_SERVER_PATH
 
 ########################## Calimero Client Tools ##############################
 cd $CALIMERO_BUILD
-git clone https://github.com/calimero-project/calimero-tools calimero-tools
+git clone https://github.com/calimero-project/calimero-tools calimero-tools || (cd calimero-tools ; git pull)
 cd calimero-tools
 ./gradlew assemble
 cp ./build/libs/calimero-tools-2.4-SNAPSHOT.jar $CALIMERO_SERVER_PATH

--- a/calimero.sh
+++ b/calimero.sh
@@ -51,6 +51,10 @@ export CALIMERO_SERVER_USER=knx
 export CALIMERO_SERVER_GROUP=knx
 # KNX Server Name
 export KNX_SERVER_NAME="Calimero KNXnet/IP Server"
+if [ "$1" = "-?" ] || [ "$1" = "-h" ] || [ "$1" = "--help" ];then
+	echo Usage $0 "[usb|tunnel ip-tunnel-endpoint]"
+	exit 0
+fi
 ###############################################################################
 # Check for root permissions
 if [ "$(id -u)" != "0" ]; then


### PR DESCRIPTION
Note, this change currently introduces a user interaction in the script because of the patch being applied twice to the launcher.

Rationale: it avoids errors like
_fatal: destination path 'calimero-core' already exists and is not an empty directory._