### PR TITLE
Add config path to classpath to allow user logger configuration

### DIFF
--- a/calimero.sh
+++ b/calimero.sh
@@ -624,7 +624,7 @@ After=network.target
 #ExecStartPre=/lib/systemd/systemd-networkd-wait-online --timeout=60
 # Wait for a specific interface
 #ExecStartPre=/lib/systemd/systemd-networkd-wait-online --timeout=60 --interface=eth0
-ExecStart=/usr/bin/java -cp "$CALIMERO_SERVER_PATH/*" tuwien.auto.calimero.server.Launcher $CALIMERO_CONFIG_PATH/server-config.xml
+ExecStart=/usr/bin/java -cp "$CALIMERO_CONFIG_PATH:$CALIMERO_SERVER_PATH/*" tuwien.auto.calimero.server.Launcher $CALIMERO_CONFIG_PATH/server-config.xml
 Type=simple
 User=$CALIMERO_SERVER_USER
 Group=$CALIMERO_SERVER_GROUP


### PR DESCRIPTION
Rationale: placing a simplelogger.properties file into the config directory, a user can adjust a few logging options for writing to the journal.

(One can set timestamps to disabled, as they should be the same as done by journald anyway.)