### PR TITLE
Clean server install directory, upgrade to v2.4

### DIFF
--- a/calimero.sh
+++ b/calimero.sh
@@ -381,14 +381,14 @@ clone_update_repo() {
 cd $CALIMERO_BUILD
 clone_update_repo calimero-core "release/2.4"
 ./gradlew install -x test
-cp ./build/libs/calimero-core-2.4-*.jar $CALIMERO_SERVER_PATH
+cp ./build/libs/calimero-core-2.4*.jar $CALIMERO_SERVER_PATH
 rm $CALIMERO_SERVER_PATH/calimero-core-2.4-*test*.jar
 
 # calimero device
 cd $CALIMERO_BUILD
 clone_update_repo calimero-device "release/2.4"
 ./gradlew install -x test
-cp ./build/libs/calimero-device-2.4-*.jar $CALIMERO_SERVER_PATH
+cp ./build/libs/calimero-device-2.4*.jar $CALIMERO_SERVER_PATH
 
 # serial-native
 cd $CALIMERO_BUILD
@@ -410,8 +410,8 @@ fi
 # calimero-rxtx
 cd $CALIMERO_BUILD
 clone_update_repo calimero-rxtx "release/2.4"
-./gradlew build
-cp ./build/libs/calimero-rxtx-2.4-*.jar $CALIMERO_SERVER_PATH 
+./gradlew build install
+cp ./build/libs/calimero-rxtx-2.4*.jar $CALIMERO_SERVER_PATH
 
 # calimero-server
 cd $CALIMERO_BUILD
@@ -419,7 +419,7 @@ clone_update_repo calimero-server "release/2.4"
 
 # mvn compile
 ./gradlew build
-cp ./build/libs/calimero-server-2.4-*.jar $CALIMERO_SERVER_PATH
+cp ./build/libs/calimero-server-2.4*.jar $CALIMERO_SERVER_PATH
 
 
 # list dependencies
@@ -452,7 +452,7 @@ cp ./build/libs/calimero-server-2.4-*.jar $CALIMERO_SERVER_PATH
 cd $CALIMERO_BUILD
 clone_update_repo calimero-tools "release/2.4"
 ./gradlew assemble
-cp ./build/libs/calimero-tools-2.4-*.jar $CALIMERO_SERVER_PATH
+cp ./build/libs/calimero-tools-2.4*.jar $CALIMERO_SERVER_PATH
 # Tools wrapper
 cat > $BIN_PATH/knxtools <<EOF
 #!/bin/sh

--- a/calimero.sh
+++ b/calimero.sh
@@ -101,7 +101,11 @@ elif [ "$1" = "clean" ]; then
 	if [ ! -z $CALIMERO_BUILD ] && [ -d $CALIMERO_BUILD ]; then
 		rm -r $CALIMERO_BUILD
 	fi
-	exit 0  
+	# Check on zero for $CALIMERO_SERVER_PATH to avoid "cleaning" the wrong directory
+	if [ ! -z $CALIMERO_SERVER_PATH ] && [ -d $CALIMERO_SERVER_PATH ]; then
+		rm -r $CALIMERO_SERVER_PATH
+	fi
+	exit 0
 elif [ "$1" = "tpuart" ] || [ "$1" = "--tpuart" ];then
     echo Configure support for TPUART
     export KNX_CONNECTION=TPUART    


### PR DESCRIPTION
*) fix "clean" target if script if was used with several different versions: the calimero server path directory will pile up with all the differently versioned .jars
*) expect a stable version number (without `-...` suffix) 