### PR TITLE
Set working directory in knx.service

### DIFF
--- a/calimero.sh
+++ b/calimero.sh
@@ -745,6 +745,7 @@ Description=Calimero KNX Daemon
 After=network.target
 
 [Service]
+WorkingDirectory=/home/$CALIMERO_SERVER_USER
 # Wait for all interfaces, systemd-networkd-wait-online.service must be enabled
 #ExecStartPre=/lib/systemd/systemd-networkd-wait-online --timeout=60
 # Wait for a specific interface


### PR DESCRIPTION
The server stores its interface object server between restarts, set the working directory to the user's home directory.